### PR TITLE
Added support for price-based discounts

### DIFF
--- a/alembic/versions/45de268cd444_add_discount_policy_id_to_price.py
+++ b/alembic/versions/45de268cd444_add_discount_policy_id_to_price.py
@@ -1,0 +1,32 @@
+"""add discount_policy_id to price
+
+Revision ID: 45de268cd444
+Revises: 4d7f840202d2
+Create Date: 2016-03-31 15:29:51.897720
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '45de268cd444'
+down_revision = '4d7f840202d2'
+
+from alembic import op  # noqa
+import sqlalchemy as sa  # noqa
+import sqlalchemy_utils  # noqa
+
+
+def upgrade():
+    op.add_column('price', sa.Column('discount_policy_id', sqlalchemy_utils.types.uuid.UUIDType(), nullable=True))
+    op.create_unique_constraint('price_item_id_discount_policy_id_key', 'price', ['item_id', 'discount_policy_id'])
+    op.create_foreign_key('price_discount_policy_id_key', 'price', 'discount_policy', ['discount_policy_id'], ['id'])
+    op.alter_column('discount_policy', 'percentage',
+               existing_type=sa.INTEGER,
+               nullable=True)
+    op.add_column('discount_policy', sa.Column('is_price_based', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_constraint('price_discount_policy_id_key', 'price', type_='foreignkey')
+    op.drop_constraint('price_item_id_discount_policy_id_key', 'price', type_='unique')
+    op.drop_column('price', 'discount_policy_id')
+    op.drop_column('discount_policy', 'is_price_based')

--- a/alembic/versions/45de268cd444_add_discount_policy_id_to_price.py
+++ b/alembic/versions/45de268cd444_add_discount_policy_id_to_price.py
@@ -10,13 +10,13 @@ Create Date: 2016-03-31 15:29:51.897720
 revision = '45de268cd444'
 down_revision = '4d7f840202d2'
 
-from alembic import op  # noqa
-import sqlalchemy as sa  # noqa
-import sqlalchemy_utils  # noqa
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
 
 
 def upgrade():
-    op.add_column('price', sa.Column('discount_policy_id', sqlalchemy_utils.types.uuid.UUIDType(), nullable=True))
+    op.add_column('price', sa.Column('discount_policy_id', sqlalchemy_utils.types.uuid.UUIDType(binary=False), nullable=True))
     op.create_unique_constraint('price_item_id_discount_policy_id_key', 'price', ['item_id', 'discount_policy_id'])
     op.create_foreign_key('price_discount_policy_id_key', 'price', 'discount_policy', ['discount_policy_id'], ['id'])
     op.alter_column('discount_policy', 'percentage',

--- a/alembic/versions/45de268cd444_add_discount_policy_id_to_price.py
+++ b/alembic/versions/45de268cd444_add_discount_policy_id_to_price.py
@@ -32,4 +32,4 @@ def downgrade():
     op.drop_column('discount_policy', 'is_price_based')
     op.alter_column('discount_policy', 'percentage',
                existing_type=sa.INTEGER,
-               nullable=True)
+               nullable=False)

--- a/alembic/versions/45de268cd444_add_discount_policy_id_to_price.py
+++ b/alembic/versions/45de268cd444_add_discount_policy_id_to_price.py
@@ -18,7 +18,7 @@ import sqlalchemy_utils
 def upgrade():
     op.add_column('price', sa.Column('discount_policy_id', sqlalchemy_utils.types.uuid.UUIDType(binary=False), nullable=True))
     op.create_unique_constraint('price_item_id_discount_policy_id_key', 'price', ['item_id', 'discount_policy_id'])
-    op.create_foreign_key('price_discount_policy_id_key', 'price', 'discount_policy', ['discount_policy_id'], ['id'])
+    op.create_foreign_key('price_discount_policy_id_fkey', 'price', 'discount_policy', ['discount_policy_id'], ['id'])
     op.alter_column('discount_policy', 'percentage',
                existing_type=sa.INTEGER,
                nullable=True)
@@ -26,7 +26,10 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_constraint('price_discount_policy_id_key', 'price', type_='foreignkey')
+    op.drop_constraint('price_discount_policy_id_fkey', 'price', type_='foreignkey')
     op.drop_constraint('price_item_id_discount_policy_id_key', 'price', type_='unique')
     op.drop_column('price', 'discount_policy_id')
     op.drop_column('discount_policy', 'is_price_based')
+    op.alter_column('discount_policy', 'percentage',
+               existing_type=sa.INTEGER,
+               nullable=True)

--- a/boxoffice/models/discount_policy.py
+++ b/boxoffice/models/discount_policy.py
@@ -13,6 +13,7 @@ __all__ = ['DiscountPolicy', 'DiscountCoupon', 'item_discount_policy', 'DISCOUNT
 class DISCOUNT_TYPE(LabeledEnum):
     AUTOMATIC = (0, __("Automatic"))
     COUPON = (1, __("Coupon"))
+    PRICE = (2, __("Price"))
 
 
 item_discount_policy = db.Table('item_discount_policy', db.Model.metadata,

--- a/boxoffice/models/discount_policy.py
+++ b/boxoffice/models/discount_policy.py
@@ -13,7 +13,6 @@ __all__ = ['DiscountPolicy', 'DiscountCoupon', 'item_discount_policy', 'DISCOUNT
 class DISCOUNT_TYPE(LabeledEnum):
     AUTOMATIC = (0, __("Automatic"))
     COUPON = (1, __("Coupon"))
-    PRICE = (2, __("Price"))
 
 
 item_discount_policy = db.Table('item_discount_policy', db.Model.metadata,
@@ -41,7 +40,9 @@ class DiscountPolicy(BaseScopedNameMixin, db.Model):
     # Minimum and maximum number of items for which the discount policy applies
     item_quantity_min = db.Column(db.Integer, default=1, nullable=False)
     item_quantity_max = db.Column(db.Integer, nullable=True)
-    percentage = db.Column(db.Integer, nullable=False)
+    percentage = db.Column(db.Integer, nullable=True)
+    # price-based discount
+    is_price_based = db.Column(db.Boolean, default=False, nullable=False)
     items = db.relationship('Item', secondary=item_discount_policy)
 
     @cached_property

--- a/boxoffice/models/item.py
+++ b/boxoffice/models/item.py
@@ -34,24 +34,31 @@ class Item(BaseScopedNameMixin, db.Model):
         """
         return self.price_at(datetime.utcnow())
 
+    def discounted_price(self, discount_policy):
+        """
+        Returns the discounted price for an item
+        """
+        return Price.query.filter(Price.item == self, Price.discount_policy == discount_policy).one_or_none()
+
     def price_at(self, timestamp):
         """
         Returns the price for an item at a given time
         """
         return Price.query.filter(Price.item == self, Price.start_at <= timestamp,
-            Price.end_at > timestamp).order_by('created_at desc').first()
+            Price.end_at > timestamp, Price.discount_policy == None).order_by('created_at desc').first()  # noqa
 
 
 class Price(BaseScopedNameMixin, db.Model):
     __tablename__ = 'price'
     __uuid_primary_key__ = True
     __table_args__ = (db.UniqueConstraint('item_id', 'name'),
-        db.CheckConstraint('start_at < end_at', 'price_start_at_lt_end_at_check'))
+        db.CheckConstraint('start_at < end_at', 'price_start_at_lt_end_at_check'),
+        db.UniqueConstraint('item_id', 'discount_policy_id'))
 
     item_id = db.Column(None, db.ForeignKey('item.id'), nullable=False)
     item = db.relationship(Item, backref=db.backref('prices', cascade='all, delete-orphan'))
 
-    discount_policy_id = db.Column(None, db.ForeignKey('discount_policy.id'), nullable=False)
+    discount_policy_id = db.Column(None, db.ForeignKey('discount_policy.id'), nullable=True)
     discount_policy = db.relationship('DiscountPolicy', backref=db.backref('price', cascade='all, delete-orphan'))
 
     parent = db.synonym('item')

--- a/boxoffice/models/item.py
+++ b/boxoffice/models/item.py
@@ -50,6 +50,10 @@ class Price(BaseScopedNameMixin, db.Model):
 
     item_id = db.Column(None, db.ForeignKey('item.id'), nullable=False)
     item = db.relationship(Item, backref=db.backref('prices', cascade='all, delete-orphan'))
+
+    discount_policy_id = db.Column(None, db.ForeignKey('discount_policy.id'), nullable=False)
+    discount_policy = db.relationship('DiscountPolicy', backref=db.backref('price', cascade='all, delete-orphan'))
+
     parent = db.synonym('item')
     start_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     end_at = db.Column(db.DateTime, nullable=False)

--- a/boxoffice/models/line_item.py
+++ b/boxoffice/models/line_item.py
@@ -106,7 +106,10 @@ class LineItemDiscounter():
             return DiscountPolicy.get_from_item(item, len(line_items))
         return DiscountPolicy.get_from_item(item, len(line_items), coupons)
 
-    def calculate_discounted_amount(self, percentage, base_amount):
+    def calculate_discounted_amount(self, discount_policy, percentage, base_amount):
+        if discount_policy.discount_type == DISCOUNT_TYPE.PRICE:
+            discounted_price = item.discounted_price(discount_policy)
+            return base_amount - discounted_price
         return (percentage * base_amount/Decimal(100))
 
     def apply_discount(self, policy_coupon, line_items, combo=False):

--- a/boxoffice/models/line_item.py
+++ b/boxoffice/models/line_item.py
@@ -128,10 +128,11 @@ class LineItemDiscounter():
         discount_policy, coupon = policy_coupon
         for line_item in line_items:
             discounted_amount = self.calculate_discounted_amount(discount_policy, line_item)
-            if should_apply_discount and discounted_amount and \
-                (not line_item.discount_policy_id or (combo and line_item.discounted_amount < discounted_amount)):  # noqa
+            if should_apply_discount and discounted_amount and (
+                not line_item.discount_policy_id or (
+                    combo and line_item.discounted_amount < discounted_amount)):
                 # if the discount policy's upper limit hasn't been reached, and if discounted_amount
-                # is positive and if the line and if the item hasn't been assigned a discount
+                # is positive and if the line item hasn't been assigned a discount
                 # or if the line item's assigned discount is lesser
                 # than the current discount, assign the current discount to the line item
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -96,3 +96,41 @@ def init_data():
     coupon3 = DiscountCoupon(code='coupon3', discount_policy=discount_coupon2, quantity_available=100, quantity_total=100)
     db.session.add(coupon3)
     db.session.commit()
+
+    forever_early_geek = DiscountPolicy(title='Forever Early Geek',
+        item_quantity_min=1,
+        is_price_based=True,
+        discount_type=DISCOUNT_TYPE.COUPON,
+        organization=rootconf)
+    forever_early_geek.items.append(conf_ticket)
+    db.session.add(forever_early_geek)
+    db.session.commit()
+
+    forever_coupon = DiscountCoupon(code='forever', discount_policy=forever_early_geek, quantity_available=100, quantity_total=100)
+    db.session.add(forever_coupon)
+    db.session.commit()
+
+    discount_price = Price(item=conf_ticket,
+        discount_policy=forever_early_geek, title='Forever Early Geek',
+        start_at=date.today(), end_at=one_month_from_now, amount=3400)
+    db.session.add(discount_price)
+    db.session.commit()
+
+    zero_discount = DiscountPolicy(title='Zero Discount',
+        item_quantity_min=1,
+        is_price_based=True,
+        discount_type=DISCOUNT_TYPE.COUPON,
+        organization=rootconf)
+    zero_discount.items.append(conf_ticket)
+    db.session.add(zero_discount)
+    db.session.commit()
+
+    zero_coupon = DiscountCoupon(code='zerodi', discount_policy=zero_discount, quantity_available=100, quantity_total=100)
+    db.session.add(zero_coupon)
+    db.session.commit()
+
+    zero_discount_price = Price(item=conf_ticket,
+        discount_policy=zero_discount, title='Zero Discount',
+        start_at=date.today(), end_at=one_month_from_now, amount=3600)
+    db.session.add(zero_discount_price)
+    db.session.commit()


### PR DESCRIPTION
An item's price can now be tagged with a discount_policy. This price will be considered independent of time constraints. Example use case: An event admin would like to provide a ticket at a special price regardless of _when_ they buy it, while maintaining the usual price tiers for other customers.