### PR TITLE
add usage_limit to discount policy for bulk coupons

### DIFF
--- a/alembic/versions/58f4f3c4fb01_add_bulk_coupon_usage_limit.py
+++ b/alembic/versions/58f4f3c4fb01_add_bulk_coupon_usage_limit.py
@@ -1,0 +1,22 @@
+"""add_bulk_coupon_usage_limit
+
+Revision ID: 58f4f3c4fb01
+Revises: 48e571c759cb
+Create Date: 2016-10-25 17:04:53.487244
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '58f4f3c4fb01'
+down_revision = '48e571c759cb'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('discount_policy', sa.Column('bulk_coupon_usage_limit', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('discount_policy', 'bulk_coupon_usage_limit')

--- a/boxoffice/models/discount_policy.py
+++ b/boxoffice/models/discount_policy.py
@@ -50,6 +50,9 @@ class DiscountPolicy(BaseScopedNameMixin, db.Model):
     secret = db.Column(db.Unicode(50), nullable=True)
 
     items = db.relationship('Item', secondary=item_discount_policy)
+    # Coupons generated in bulk are not stored in the database during generation.
+    # This field allows specifying the number of times a coupon, generated in bulk, can be used
+    bulk_coupon_usage_limit = db.Column(db.Integer, nullable=True, default=1)
 
     @cached_property
     def is_automatic(self):

--- a/boxoffice/models/line_item.py
+++ b/boxoffice/models/line_item.py
@@ -253,7 +253,7 @@ def get_from_item(cls, item, qty, coupon_codes=[]):
                 if policy and policy.id in coupon_policy_ids:
                     coupon = DiscountCoupon.query.filter_by(discount_policy=policy, code=coupon_code).one_or_none()
                     if not coupon:
-                        coupon = DiscountCoupon(discount_policy=policy, code=coupon_code, usage_limit=1, used_count=0)
+                        coupon = DiscountCoupon(discount_policy=policy, code=coupon_code, usage_limit=policy.bulk_coupon_usage_limit, used_count=0)
                         db.session.add(coupon)
                 else:
                     coupon = None

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -168,7 +168,7 @@ def init_data():
         db.session.add(zero_discount_price)
         db.session.commit()
 
-        bulk = DiscountPolicy.make_bulk('signed', organization=rootconf, title='Signed', percentage=10)
+        bulk = DiscountPolicy.make_bulk('signed', organization=rootconf, title='Signed', percentage=10, bulk_coupon_usage_limit=2)
         bulk.items.append(conf_ticket)
         db.session.add(bulk)
         db.session.commit()

--- a/tests/test_kharcha.py
+++ b/tests/test_kharcha.py
@@ -105,7 +105,7 @@ class TestKharchaAPI(unittest.TestCase):
         first_item = Item.query.filter_by(name='conference-ticket').first()
         signed_policy = DiscountPolicy.query.filter_by(name='signed').first()
         code = signed_policy.gen_signed_code()
-        discounted_quantity = 1
+        discounted_quantity = 2
         kharcha_req = {'line_items': [{'item_id': unicode(first_item.id), 'quantity': discounted_quantity}], 'discount_coupons': [code]}
         resp = self.client.post(url_for('kharcha'), data=json.dumps(kharcha_req), content_type='application/json', headers=[('X-Requested-With', 'XMLHttpRequest'), ('Origin', app.config['BASE_URL'])])
         self.assertEquals(resp.status_code, 200)


### PR DESCRIPTION
This change will allow coupons generated in bulk, which aren't stored during generation, to have a customizable usage limit.