### PR TITLE
Fix 105

### DIFF
--- a/boxoffice/mailclient.py
+++ b/boxoffice/mailclient.py
@@ -19,7 +19,10 @@ def send_receipt_mail(order_id, subject="Thank you for your order!"):
         order = Order.query.get(order_id)
         msg = Message(subject=subject, recipients=[order.buyer_email], bcc=[order.organization.contact_email])
         line_items = LineItem.query.filter(LineItem.order == order, LineItem.status == LINE_ITEM_STATUS.CONFIRMED).order_by("line_item_seq asc").all()
-        html = email_transform(render_template('order_confirmation_mail.html', order=order, org=order.organization, line_items=line_items, base_url=app.config['BASE_URL']))
+        html = email_transform(render_template('order_confirmation_mail.html', order=order, org=order.organization,
+            line_items=line_items,
+            order_confirmed_amount=order.get_amounts(LINE_ITEM_STATUS.CONFIRMED).confirmed_amount,
+            base_url=app.config['BASE_URL']))
         msg.html = html
         msg.body = html2text(html)
         mail.send(msg)

--- a/boxoffice/mailclient.py
+++ b/boxoffice/mailclient.py
@@ -40,7 +40,7 @@ def send_participant_assignment_mail(order_id, item_collection_title, team_membe
 
 
 @job('boxoffice')
-def send_line_item_cancellation_mail(line_item_id, subject="Ticket Cancellation"):
+def send_line_item_cancellation_mail(line_item_id, refund_amount, subject="Ticket Cancellation"):
     with app.test_request_context():
         line_item = LineItem.query.get(line_item_id)
         item_title = line_item.item.title
@@ -51,7 +51,7 @@ def send_line_item_cancellation_mail(line_item_id, subject="Ticket Cancellation"
         html = email_transform(render_template('line_item_cancellation_mail.html',
             base_url=app.config['BASE_URL'],
             order=order, line_item=line_item, item_title=item_title, org=order.organization, is_paid=is_paid,
-            currency_symbol=CURRENCY_SYMBOL['INR']))
+            refund_amount=refund_amount, currency_symbol=CURRENCY_SYMBOL['INR']))
         msg.html = html
         msg.body = html2text(html)
         mail.send(msg)

--- a/boxoffice/models/discount_policy.py
+++ b/boxoffice/models/discount_policy.py
@@ -53,6 +53,9 @@ class DiscountPolicy(BaseScopedNameMixin, db.Model):
     items = db.relationship('Item', secondary=item_discount_policy)
     # Coupons generated in bulk are not stored in the database during generation.
     # This field allows specifying the number of times a coupon, generated in bulk, can be used
+    # This is particularly useful for generating referral discount coupons. For instance, one could generate
+    # a signed coupon and provide it to a user such that the user can share the coupon `n` times
+    # `n` here is essentially bulk_coupon_usage_limit.
     bulk_coupon_usage_limit = db.Column(db.Integer, nullable=True, default=1)
 
     @cached_property

--- a/boxoffice/models/item.py
+++ b/boxoffice/models/item.py
@@ -70,7 +70,7 @@ class Item(BaseScopedNameMixin, db.Model):
         return bool(self.current_price() and self.quantity_available > 0)
 
     def is_cancellable(self):
-        return datetime.now() < self.cancellable_until if self.cancellable_until else True
+        return datetime.utcnow() < self.cancellable_until if self.cancellable_until else True
 
 
 class Price(BaseScopedNameMixin, db.Model):

--- a/boxoffice/models/item.py
+++ b/boxoffice/models/item.py
@@ -69,6 +69,9 @@ class Item(BaseScopedNameMixin, db.Model):
         """Checks if an item has a current price object and has a positive quantity_available"""
         return bool(self.current_price() and self.quantity_available > 0)
 
+    def is_cancellable(self):
+        return datetime.now() < self.cancellable_until if self.cancellable_until else True
+
 
 class Price(BaseScopedNameMixin, db.Model):
     __tablename__ = 'price'

--- a/boxoffice/models/line_item.py
+++ b/boxoffice/models/line_item.py
@@ -22,8 +22,10 @@ class LINE_ITEM_STATUS(LabeledEnum):
     VOID = (3, __("Void"))
 
 
+line_item_tup = namedtuple('LineItem', ['item_id', 'id', 'base_amount', 'discount_policy_id', 'discount_coupon_id', 'discounted_amount', 'final_amount'])
+
+
 def make_ntuple(item_id, base_amount, **kwargs):
-    line_item_tup = namedtuple('LineItem', ['item_id', 'id', 'base_amount', 'discount_policy_id', 'discount_coupon_id', 'discounted_amount', 'final_amount'])
     return line_item_tup(item_id,
         kwargs.get('line_item_id', None),
         base_amount,

--- a/boxoffice/models/order.py
+++ b/boxoffice/models/order.py
@@ -84,22 +84,20 @@ class Order(BaseMixin, db.Model):
         self.invoiced_at = datetime.utcnow()
         self.status = ORDER_STATUS.INVOICE
 
-    def get_amounts(self):
+    def get_amounts(self, line_item_status):
         """
         Calculates and returns the order's base_amount, discounted_amount,
-        final_amount, confirmed_amount as a namedtuple.
-
-        Note: base_amount, discounted_amount, final_amount are calculated for ALL of the order's line items,
-        whereas confirmed_amount is calculated only for the order's confirmed line items.
+        final_amount, confirmed_amount as a namedtuple for all the line items with the given status.
         """
         base_amount = Decimal(0)
         discounted_amount = Decimal(0)
         final_amount = Decimal(0)
         confirmed_amount = Decimal(0)
         for line_item in self.line_items:
-            base_amount += line_item.base_amount
-            discounted_amount += line_item.discounted_amount
-            final_amount += line_item.final_amount
+            if line_item.status == line_item_status:
+                base_amount += line_item.base_amount
+                discounted_amount += line_item.discounted_amount
+                final_amount += line_item.final_amount
             if line_item.is_confirmed:
                 confirmed_amount += line_item.final_amount
         return order_amounts_ntuple(base_amount, discounted_amount, final_amount, confirmed_amount)

--- a/boxoffice/templates/cash_receipt.html
+++ b/boxoffice/templates/cash_receipt.html
@@ -241,7 +241,7 @@
       <tr>
           <td></td>
           <td colspan="2" class="total gray">Total</td>
-          <td class="total-amount gray center"><div id="total">&#8377; {{ order.get_amounts().confirmed_amount }}</div></td>
+          <td class="total-amount gray center"><div id="total">&#8377; {{ order_confirmed_amount }}</div></td>
       </tr>
     </table>
     

--- a/boxoffice/templates/line_item_cancellation_mail.html
+++ b/boxoffice/templates/line_item_cancellation_mail.html
@@ -40,7 +40,7 @@
 
     <p>With reference to your order (Receipt No: {{ order.invoice_no }}), "{{ item_title }}" has been cancelled.</p>
     {%- if is_paid %}
-      <p>A refund of {{currency_symbol}} {{line_item.final_amount}} has been initiated. You should receive the refund in 2-5 days.</p>
+      <p>A refund of {{currency_symbol}} {{refund_amount}} has been initiated. You should receive the refund in 2-5 days.</p>
     {%- endif %}
   
     <p class="footer">Thank you,</p>

--- a/boxoffice/templates/line_item_cancellation_mail.html
+++ b/boxoffice/templates/line_item_cancellation_mail.html
@@ -40,7 +40,7 @@
 
     <p>With reference to your order (Receipt No: {{ order.invoice_no }}), "{{ item_title }}" has been cancelled.</p>
     {%- if is_paid %}
-      <p>A refund of {{currency_symbol}} {{refund_amount}} has been initiated. You should receive the refund in 2-5 days.</p>
+      <p>A refund of {{ currency_symbol }} {{ refund_amount }} has been initiated. You should receive the refund in 2-5 days.</p>
     {%- endif %}
   
     <p class="footer">Thank you,</p>

--- a/boxoffice/templates/order_confirmation_mail.html
+++ b/boxoffice/templates/order_confirmation_mail.html
@@ -239,7 +239,7 @@
       <tr>
           <td></td>
           <td colspan="2" class="total gray">Total</td>
-          <td class="total-amount gray center"><div id="total">&#8377; {{ order.get_amounts().confirmed_amount }}</div></td>
+          <td class="total-amount gray center"><div id="total">&#8377; {{ order_confirmed_amount }}</div></td>
       </tr>
     </table>
     

--- a/boxoffice/views/order.py
+++ b/boxoffice/views/order.py
@@ -367,10 +367,12 @@ def update_order_on_line_item_cancellation(order, pre_cancellation_line_items, c
     active_line_items = [pre_cancellation_line_item
         for pre_cancellation_line_item in pre_cancellation_line_items
         if pre_cancellation_line_item != cancelled_line_item]
-    recalculated_line_item_tups = LineItem.calculate(active_line_items, recalculate=True, coupons=get_coupon_codes_from_line_items(active_line_items))
+    recalculated_line_item_tups = LineItem.calculate(active_line_items, recalculate=True,
+        coupons=get_coupon_codes_from_line_items(active_line_items))
 
     last_line_item_seq = LineItem.get_max_seq(order)
     for idx, line_item_tup in enumerate(recalculated_line_item_tups, start=last_line_item_seq+1):
+        # Fetch the line item object
         pre_cancellation_line_item = [pre_cancellation_line_item for pre_cancellation_line_item in pre_cancellation_line_items if pre_cancellation_line_item.id == line_item_tup.id][0]
         # Check if the line item's amount has changed post-cancellation
         if line_item_tup.final_amount != pre_cancellation_line_item.final_amount:


### PR DESCRIPTION
- Fixes [order calculation on cancelling a line item that has availed a bulk discount](https://github.com/hasgeek/boxoffice/issues/105).
- Introduces a new status for line item - `VOID`, used to mark line items that are no longer valid. This is different from `CANCELLED`, since the latter is initiated by the user.