### PR TITLE
Include refunded_at and refund_description in ticket cancellation workflow

### DIFF
--- a/boxoffice/templates/cash_receipt.html
+++ b/boxoffice/templates/cash_receipt.html
@@ -237,7 +237,13 @@
         {% for transaction in order.refund_transactions -%}
           <tr>
               <td></td>
-              <td colspan="2">{{ transaction.refund_description }}</td>
+              {%- if transaction.refund_description %}
+                <td colspan="2">{{ transaction.refund_description }}</td>
+              {%- elif transaction.refunded_at %}
+                <td colspan="2">Refund on {{ transaction.refunded_at | invoice_date('%d %b %Y') }}</td>
+              {%- else %}
+                <td colspan="2">Refund</td>
+              {%- endif %}
               <td class="total-amount center"><div id="total">&#8377; {{ transaction.amount }}</div></td>
           </tr>
         {%- endfor %}

--- a/boxoffice/templates/cash_receipt.html
+++ b/boxoffice/templates/cash_receipt.html
@@ -240,7 +240,7 @@
               {%- if transaction.refund_description %}
                 <td colspan="2">{{ transaction.refund_description }}</td>
               {%- elif transaction.refunded_at %}
-                <td colspan="2">Refund on {{ transaction.refunded_at | invoice_date('%d %b %Y') }}</td>
+                <td colspan="2">Refunded on {{ transaction.refunded_at | invoice_date('%d %b %Y') }}</td>
               {%- else %}
                 <td colspan="2">Refund</td>
               {%- endif %}

--- a/boxoffice/views/order.py
+++ b/boxoffice/views/order.py
@@ -409,7 +409,8 @@ def process_line_item_cancellation(line_item):
         rp_resp = razorpay.refund_payment(payment.pg_paymentid, refund_amount)
         if rp_resp.status_code == 200:
             db.session.add(PaymentTransaction(order=order, transaction_type=TRANSACTION_TYPE.REFUND,
-                online_payment=payment, amount=refund_amount, currency=CURRENCY.INR, refunded_at=func.utcnow(), refund_description='{ticket} cancelled'.format(ticket=line_item.item.title)))
+                online_payment=payment, amount=refund_amount, currency=CURRENCY.INR, refunded_at=func.utcnow(),
+                refund_description='Refund: {line_item_title}'.format(line_item_title=line_item.item.title)))
         else:
             raise PaymentGatewayError("Cancellation failed for order - {order} with the following details - {msg}".format(order=order.id,
                 msg=rp_resp.content), 424,

--- a/boxoffice/views/order.py
+++ b/boxoffice/views/order.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from decimal import Decimal
+from sqlalchemy.sql import func
 from flask import url_for, request, jsonify, render_template, make_response, abort
 from coaster.views import render_with, load_models
 from baseframe import _
@@ -408,7 +409,7 @@ def process_line_item_cancellation(line_item):
         rp_resp = razorpay.refund_payment(payment.pg_paymentid, refund_amount)
         if rp_resp.status_code == 200:
             db.session.add(PaymentTransaction(order=order, transaction_type=TRANSACTION_TYPE.REFUND,
-                online_payment=payment, amount=refund_amount, currency=CURRENCY.INR))
+                online_payment=payment, amount=refund_amount, currency=CURRENCY.INR, refunded_at=func.utcnow(), refund_description='{ticket} cancelled'.format(ticket=line_item.item.title)))
         else:
             raise PaymentGatewayError("Cancellation failed for order - {order} with the following details - {msg}".format(order=order.id,
                 msg=rp_resp.content), 424,


### PR DESCRIPTION
1. Add `refunded_at` and `refund_description` in `process_line_item_cancellation` call
2. Add default message for refunds in cash receipt.