### PR TITLE
Fixed travis build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ install:
   - pip install -r requirements.txt
   - pip install https://github.com/hasgeek/coaster/archive/master.zip
   - npm install casperjs
+env:
+  - FLASK_ENV=testing
 script:
   - ./runtests.sh
 after_success:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ nocapture=1
 cover-package=boxoffice
 cover-erase=1
 with-doctest=1
+where=tests

--- a/tests/test_item_collection.py
+++ b/tests/test_item_collection.py
@@ -49,7 +49,6 @@ class TestItemCollectionAPI(unittest.TestCase):
     def setUp(self):
         self.ctx = app.test_request_context()
         self.ctx.push()
-        db.create_all()
         init_data()
         self.client = app.test_client()
         ic = ItemCollection.query.first()

--- a/tests/test_kharcha.py
+++ b/tests/test_kharcha.py
@@ -186,9 +186,9 @@ class TestKharchaAPI(unittest.TestCase):
         coupon = DiscountCoupon.query.filter_by(code='noprice').first()
         discounted_quantity = 1
         kharcha_req = {'line_items': [{'item_id': unicode(first_item.id), 'quantity': discounted_quantity}], 'discount_coupons': [coupon.code]}
-        print first_item.discount_policies.all()
+        # print first_item.discount_policies.all()
         resp = self.client.post(url_for('kharcha'), data=json.dumps(kharcha_req), content_type='application/json', headers=[('X-Requested-With', 'XMLHttpRequest'), ('Origin', app.config['BASE_URL'])])
-        print resp.status_code
+        # print resp.status_code
         self.assertEquals(resp.status_code, 200)
         resp_json = json.loads(resp.get_data())
 

--- a/tests/test_kharcha.py
+++ b/tests/test_kharcha.py
@@ -13,8 +13,6 @@ class TestKharchaAPI(unittest.TestCase):
     def setUp(self):
         self.ctx = app.test_request_context()
         self.ctx.push()
-        db.drop_all()
-        db.create_all()
         init_data()
         self.client = app.test_client()
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -18,7 +18,6 @@ class TestOrder(unittest.TestCase):
     def setUp(self):
         self.ctx = app.test_request_context()
         self.ctx.push()
-        db.create_all()
         init_data()
         self.client = app.test_client()
 


### PR DESCRIPTION
Previously `nosetests` had to be told where the tests are explicitly, I removed that when updating travis config with runtests. added `where` config to `setup.cfg` to fix it.

Also removed some redundant `drop_all()` and `create_all()` statements. `init_data()` does both. All the tests call `init_data()` in their `setUp()` function.