### PR TITLE
make title customizable, read discount coupons from parent window if …

### DIFF
--- a/boxoffice/templates/boxoffice.js
+++ b/boxoffice/templates/boxoffice.js
@@ -27,7 +27,9 @@ $(function() {
   boxoffice.util.getQueryParams = function() {
     // Returns an array of query parameters
     // Eg: "?code=xxx&cody=yyy" -> ["code=xxx", "code=yyy"]
-    var searchStr = window.location.search.split('?');
+
+    // Use the parent window's URL if executed in an iframe, else use the current window's URL
+    var searchStr = (window.location !== window.parent.location ? document.referrer : window.location.search).split('?');
     if (searchStr.length > 1) {
       return searchStr[1].split('&');
     }

--- a/boxoffice/templates/item_collection_listing.html.jinja2
+++ b/boxoffice/templates/item_collection_listing.html.jinja2
@@ -14,16 +14,17 @@
 {% block main -%}
   <div id="sidebar"></div>
   <div id="main-content-area">
-
-    <div class='container'>
-    <div class='row'>
-      <div class='col-xs-12'>
-        <h1 class='boxoffice-listing'>
-          {{organization.title}}: {{item_collection.title}}
-        </h1>
+    {% if show_title %}
+      <div class='container'>
+        <div class='row'>
+          <div class='col-xs-12'>
+            <h1 class='boxoffice-listing'>
+              {{organization.title}}: {{item_collection.title}}
+            </h1>
+          </div>
+        </div>
       </div>
-    </div>
-    </div>
+    {% endif %}
     <div id="boxoffice-widget"><p class="text-center regular col-sm-8 col-sm-offset-2 col-xs-12">Loading...</p></div>
   </div>
 {% endblock %}
@@ -72,7 +73,7 @@
             }
           }
         }
+      });
     });
-  });
   </script>
 {% endblock %}

--- a/boxoffice/views/item_collection.py
+++ b/boxoffice/views/item_collection.py
@@ -79,6 +79,8 @@ def item_collection(item_collection):
     (ItemCollection, {'name': 'item_collection_name', 'organization': 'organization'}, 'item_collection')
     )
 def item_collection_listing(organization, item_collection):
+    show_title = False if request.args.get('show_title') == 'f' else True
     return render_template('item_collection_listing.html.jinja2',
         organization=organization,
-        item_collection=item_collection)
+        item_collection=item_collection,
+        show_title=show_title)

--- a/boxoffice/views/item_collection.py
+++ b/boxoffice/views/item_collection.py
@@ -3,6 +3,7 @@
 from flask import make_response, render_template, jsonify, request
 from pycountry import pycountry
 from coaster.views import load_models
+from coaster.utils import getbool
 from boxoffice import app
 from boxoffice.models import Organization, ItemCollection, Item
 from utils import xhr_only, cors
@@ -79,7 +80,7 @@ def item_collection(item_collection):
     (ItemCollection, {'name': 'item_collection_name', 'organization': 'organization'}, 'item_collection')
     )
 def item_collection_listing(organization, item_collection):
-    show_title = False if request.args.get('show_title') == 'f' else True
+    show_title = getbool(request.args.get('show_title', True))
     return render_template('item_collection_listing.html.jinja2',
         organization=organization,
         item_collection=item_collection,


### PR DESCRIPTION
Changes:
- Makes the `title` on the ticket listing page optional. This is useful if this page is embedded as an iframe.
- If the ticketing widget is embedded in an iframe, discount coupons are checked for in the parent window. 