### PR TITLE
Rename form field from "items" to "tickets"

### DIFF
--- a/boxoffice/assets/js/templates/admin_discount_policy.html.js
+++ b/boxoffice/assets/js/templates/admin_discount_policy.html.js
@@ -262,7 +262,7 @@ export const DiscountPolicyTemplate = `
 
                     <p class="field-title filled">What is the discount for?</p>
                     <div class="group">
-                      <select {{#if is_price_based}}name="ticket" id="add-item-{{ id }}"{{else}}name="items" id="add-items-{{ id }}" multiple{{/if}} class="items-select2">
+                      <select {{#if is_price_based}}name="ticket" id="add-item-{{ id }}"{{else}}name="tickets" id="add-items-{{ id }}" multiple{{/if}} class="items-select2">
                         {{#dp_items:ticket}}
                           <option value="{{ dp_items[ticket].id }}" selected title="{{ dp_items[ticket].title }}">{{ dp_items[ticket].title }}</option>
                         {{/}}

--- a/boxoffice/views/admin_discount.py
+++ b/boxoffice/views/admin_discount.py
@@ -194,6 +194,8 @@ def admin_edit_discount_policy(discount_policy: DiscountPolicy) -> Response:
                 status_code=400,
                 errors=discount_price_form.errors,
             )
+        # FIXME: What's happening here? It's creating a Price object and associating it
+        # with which ticket? What if the policy applies to multiple tickets?
         discount_price_form.populate_obj(discount_price)
         if (
             discount_policy.tickets


### PR DESCRIPTION
The discount policy edit form was broken. This fixes it.